### PR TITLE
Change class name for method getPodcastId.

### DIFF
--- a/src/main/java/razborpoletov/reader/converters/PodcastFile.java
+++ b/src/main/java/razborpoletov/reader/converters/PodcastFile.java
@@ -8,6 +8,7 @@ import org.jsoup.select.Elements;
 import razborpoletov.reader.parsers.FileParser;
 import razborpoletov.reader.parsers.StatisticParser;
 import razborpoletov.reader.utils.MarkdownUtils;
+import razborpoletov.reader.utils.PodcastFileUtils;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -58,7 +59,7 @@ public class PodcastFile {
         StatisticParser parser = new StatisticParser();
         this.originalFile = originalFile;
         mp3FileLength = parser.getFileSize(originalFile);
-        id = FileParser.getPodcastId(originalFile);
+        id = PodcastFileUtils.getPodcastId(originalFile);
         outputFilename = String.format("%s.adoc", FilenameUtils.getBaseName(originalFile
                 .getName()));
         outputFile = String.format("%s%s", INTERMEDIATE_FILES_FOLDER,


### PR DESCRIPTION
FileParser doesn't have public static long getPodcastId(File file) method since last commit.
Now the project compiles.
